### PR TITLE
[rust] we can use stable now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ osx_image: xcode8.2
 
 before_install:
   - brew update
-  - curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
+  - curl -s https://static.rust-lang.org/rustup.sh | sh -s
   - export PATH="$PATH:$HOME/.cargo/bin"
 
 install:

--- a/天体.rs
+++ b/天体.rs
@@ -1,5 +1,3 @@
-#![feature(non_ascii_idents)]
-
 struct 天体;
 
 impl 天体 {


### PR DESCRIPTION
since 1.53.0 we can use non_ascii_ident without feature flags.